### PR TITLE
Pass error message back to caller

### DIFF
--- a/lib/saml_parse.rb
+++ b/lib/saml_parse.rb
@@ -10,7 +10,8 @@ class SamlParse
   #
   # @param format [String] a metadata url
   # @param format [Hash] key :digest_algorithm. Optional agr. Defaults to SHA256
-  # @return [XmlParser Object].
+  # @return [XmlParser Object]
+  # @return [Array<Hash{Symbol, String}>] on error. Hash keys :user_message, :error
   def self.parse(metadata_url, options = {})
     xml_document_object = FetchXml.new(metadata_url).fetch
 

--- a/lib/saml_parse.rb
+++ b/lib/saml_parse.rb
@@ -17,7 +17,7 @@ class SamlParse
     if xml_document_object.ok?
       parsed_saml_object = XmlParser.new(xml_document_object.document, options).parse
     else
-      return xml_document_object.errors.join(', ')
+      return xml_document_object.errors
     end
 
     parsed_saml_object

--- a/lib/saml_parse.rb
+++ b/lib/saml_parse.rb
@@ -22,6 +22,6 @@ class SamlParse
 
     parsed_saml_object
     rescue DigestNotSupported => _e
-      "#{ErrorMessages::MESSAGE_MAPPINGS[:digest_not_supported]} #{XmlParser::SUPPORTED_DIGESTS.join(', ')}"
+      { user_message: ErrorMessages::MESSAGE_MAPPINGS[:digest_not_supported],  error: XmlParser::SUPPORTED_DIGESTS.join(', ') }
   end
 end

--- a/lib/saml_parser/fetch_xml.rb
+++ b/lib/saml_parser/fetch_xml.rb
@@ -75,7 +75,7 @@ class FetchXml
     response_xml = Nokogiri::XML(xml)
 
     unless response_xml.errors.empty?
-      errors << ErrorMessages::MESSAGE_MAPPINGS[:invalid_xml]
+      handle_error(ErrorMessages::MESSAGE_MAPPINGS[:invalid_xml], response_xml.errors)
       return
     end
     response_xml.remove_namespaces!

--- a/lib/saml_parser/fetch_xml.rb
+++ b/lib/saml_parser/fetch_xml.rb
@@ -58,7 +58,13 @@ class FetchXml
     response.body
   rescue Net::OpenTimeout, Net::ReadTimeout => e
     handle_error(ErrorMessages::MESSAGE_MAPPINGS[:http_timeout], error: e.message)
-  rescue URI::InvalidURIError, SsrfFilter::InvalidUriScheme, SsrfFilter::PrivateIPAddress => _e
+  rescue URI::InvalidURIError,
+         SsrfFilter::InvalidUriScheme,
+         SsrfFilter::PrivateIPAddress,
+         SsrfFilter::Error,
+         SsrfFilter::UnresolvedHostname,
+         SsrfFilter::TooManyRedirects,
+         SsrfFilter::CRLFInjection => e
     handle_error(ErrorMessages::MESSAGE_MAPPINGS[:http_error], error: e.message)
   end
 

--- a/lib/saml_parser/fetch_xml.rb
+++ b/lib/saml_parser/fetch_xml.rb
@@ -20,7 +20,7 @@ class FetchXml
 
   def initialize(metadata_url)
     @metadata_url = metadata_url
-    @errors = []
+    @errors = [{}]
   end
 
   # @return [FetchXml Object]
@@ -34,7 +34,7 @@ class FetchXml
   # Used to check if the instance generated any errors.
   # @return [Boolean]
   def ok?
-    errors.empty?
+    errors.all?(&:empty?)
   end
 
   private

--- a/lib/saml_parser/fetch_xml.rb
+++ b/lib/saml_parser/fetch_xml.rb
@@ -51,14 +51,15 @@ class FetchXml
       })
 
     if response.code.to_i != SUCCESS_RESPONSE
-      return errors << ErrorMessages::MESSAGE_MAPPINGS[:unsuccessful_response_code]
+      handle_error(ErrorMessages::MESSAGE_MAPPINGS[:unsuccessful_response_code], response.message)
+      return errors
     end
 
     response.body
-  rescue Net::OpenTimeout, Net::ReadTimeout => _e
-    errors << ErrorMessages::MESSAGE_MAPPINGS[:http_timeout]
+  rescue Net::OpenTimeout, Net::ReadTimeout => e
+    handle_error(ErrorMessages::MESSAGE_MAPPINGS[:http_timeout], error: e.message)
   rescue URI::InvalidURIError, SsrfFilter::InvalidUriScheme, SsrfFilter::PrivateIPAddress => _e
-    errors << ErrorMessages::MESSAGE_MAPPINGS[:http_error]
+    handle_error(ErrorMessages::MESSAGE_MAPPINGS[:http_error], error: e.message)
   end
 
   # Handles a request
@@ -72,5 +73,10 @@ class FetchXml
       return
     end
     response_xml.remove_namespaces!
+  end
+
+
+  def handle_error(user_message, error)
+    errors << { user_message: user_message, error: error }
   end
 end

--- a/lib/saml_parser/fetch_xml.rb
+++ b/lib/saml_parser/fetch_xml.rb
@@ -81,7 +81,9 @@ class FetchXml
     response_xml.remove_namespaces!
   end
 
-
+  # Holds the possible errors
+  # @param String, String
+  # @return [Array<Hash{Symbol, String}>] on error. Hash keys :user_message, :error
   def handle_error(user_message, error)
     errors << { user_message: user_message, error: error }
   end


### PR DESCRIPTION
When using the library it may be useful for the developer to know which errors were raised. As such when an error is raised, an array of hashes is now returned. The uncased hashes have keys of user_message and error. The user_message key contains the system generated error messages which are suitable to display to the user. The error key will give back the exception message to allow the developer to decide further action to take if any.